### PR TITLE
GitHub detail viewmodel

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -36,9 +36,22 @@ class MainActivity : ComponentActivity() {
                             },
                         )
                     }
-                    composable(route = ViewRoute.GithubDetailView.route) {
+                    composable(
+                        route = ViewRoute.GithubDetailView.route,
+                        arguments =
+                        listOf(
+                            navArgument("repositoryId") {
+                                type = NavType.StringType
+                            },
+                            navArgument("owner") {
+                                type = NavType.StringType
+                            },
+                        ),
+                    ) { backStackEntry ->
                         GithubDetailView(
-                            goToSearchView = {},
+                            goToSearchView = { navController.navigate(ViewRoute.SearchGithubView.route) },
+                            repositoryName = checkNotNull(backStackEntry.arguments?.getString("repositoryId")),
+                            repositoryOwner = checkNotNull(backStackEntry.arguments?.getString("owner")),
                         )
                     }
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -26,7 +26,14 @@ class MainActivity : ComponentActivity() {
                 ) {
                     composable(route = ViewRoute.SearchGithubView.route) {
                         SearchGithubView(
-                            goToDetailView = {},
+                            goToDetailView = { it ->
+                                navController.navigate(
+                                    ViewRoute.GithubDetailView.route.replace(
+                                        "{repositoryName}",
+                                        it.name,
+                                    ).replace("{owner}", it.owner.name),
+                                )
+                            },
                         )
                     }
                     composable(route = ViewRoute.GithubDetailView.route) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : ComponentActivity() {
                 ) {
                     composable(route = ViewRoute.SearchGithubView.route) {
                         SearchGithubView(
-                            goToDetailView = { it ->
+                            goToDetailView = {
                                 navController.navigate(
                                     ViewRoute.GithubDetailView.route.replace(
                                         "{repositoryName}",

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.ui.theme.YumemiCodeCheckTheme
 import jp.co.yumemi.android.code_check.view.GithubDetailView

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ViewRoute.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ViewRoute.kt
@@ -1,5 +1,7 @@
 package jp.co.yumemi.android.code_check
+
 sealed class ViewRoute(val route: String) {
-    object SearchGithubView : ViewRoute("SearchGithubView")
-    object GithubDetailView : ViewRoute("GithubDetailView")
+    object SearchGithubView : ViewRoute("searchGithubView")
+
+    object GithubDetailView : ViewRoute("githubDetailView/{repositoryId}")
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/common/State/GithubRepositoryState.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/common/State/GithubRepositoryState.kt
@@ -1,9 +1,7 @@
 package jp.co.yumemi.android.code_check.common.State
 
-import jp.co.yumemi.android.code_check.model.Item
-
-data class GithubRepositoryState(
+data class GithubRepositoryState<T>(
     val isLoading: Boolean = false,
-    val data: List<Item> = emptyList(),
-    val error: String? = null
+    val data: T? = null,
+    val error: String? = null,
 )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/Owner.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/model/Owner.kt
@@ -5,5 +5,6 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class Owner(
-    @Json(name = "avatar_url") val avatarUrl: String
+    @Json(name = "avatar_url") val avatarUrl: String,
+    @Json(name = "login") val name: String,
 )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubRepository.kt
@@ -1,12 +1,22 @@
 package jp.co.yumemi.android.code_check.repository
 
+import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.model.SearchGithubRepositoryModel
 import javax.inject.Inject
 
-class GithubRepository @Inject constructor(
-    private val githubService: GithubService
+class GithubRepository
+@Inject
+constructor(
+    private val githubService: GithubService,
 ) {
     suspend fun searchGithubRepository(query: String): SearchGithubRepositoryModel {
         return githubService.searchGithubRepository(query)
+    }
+
+    suspend fun getGithubDetail(
+        owner: String,
+        name: String,
+    ): Item {
+        TODO()
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/GithubDetailView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/GithubDetailView.kt
@@ -1,14 +1,18 @@
 package jp.co.yumemi.android.code_check.view
 
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
@@ -27,13 +31,27 @@ fun GithubDetailView(
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AsyncImage(
-            model = "https://i0.wp.com/theboreddev.com/wp-content/uploads/2021/10/kotlin_front.png?w=800&ssl=1",
-            contentDescription = null,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp)
-        )
+        val state = viewModel.state.value
+        val ctx = LocalContext.current
+        when {
+            state.isLoading -> {
+                CircularProgressIndicator()
+            }
+
+            !state.error.isNullOrBlank() -> {
+                Toast.makeText(ctx, "レポジトリを検索できませんでした", Toast.LENGTH_LONG).show()
+                Log.d("Error", state.error)
+            }
+
+            state.data != null -> {
+                AsyncImage(
+                    model = state.data.owner.avatarUrl,
+                    contentDescription = state.data.name,
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                )
 
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/GithubDetailView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/GithubDetailView.kt
@@ -10,15 +10,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import jp.co.yumemi.android.code_check.ui.theme.Typography
+import jp.co.yumemi.android.code_check.viewModel.GithubDetailViewModel
 
 @Composable
-fun GithubDetailView(goToSearchView: () -> Unit) {
+fun GithubDetailView(
+    goToSearchView: () -> Unit,
+    repositoryName: String,
+    repositoryOwner: String,
+    viewModel: GithubDetailViewModel = hiltViewModel(),
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AsyncImage(
             model = "https://i0.wp.com/theboreddev.com/wp-content/uploads/2021/10/kotlin_front.png?w=800&ssl=1",
@@ -28,28 +35,19 @@ fun GithubDetailView(goToSearchView: () -> Unit) {
                 .padding(vertical = 8.dp)
         )
 
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(text = "name", style = Typography.bodyLarge)
-            Text(text = "written in language", style = Typography.bodyLarge)
-            Text(text = "star count", style = Typography.bodyLarge)
-            Text(text = "watcherCount", style = Typography.bodyLarge)
-            Text(text = "forkCount", style = Typography.bodyLarge)
-            Text(text = "owner")
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(text = state.data.name, style = Typography.bodyLarge)
+                    Text(text = state.data.language ?: "No Language", style = Typography.bodyLarge)
+                    Text(text = "Star Count: ${state.data.stargazersCount}", style = Typography.bodyLarge)
+                    Text(text = "watcherCount ${state.data.watchersCount}", style = Typography.bodyLarge)
+                    Text(text = "forkCount: ${state.data.forksCount}", style = Typography.bodyLarge)
+                    Text(text = "owner: ${state.data.owner}")
+                }
+            }
         }
     }
 }
-
-/**
- *
-val name: String,
-val forksCount: Int?,
-val openIssuesCount: Int,
-val language: String?,
-val stargazersCount: Int?,
-val watchersCount: Int?,
-val owner: Owner,
- */

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchGithubView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchGithubView.kt
@@ -64,7 +64,6 @@ fun SearchGithubView(
             val ctx = LocalContext.current
             when {
                 state.isLoading -> {
-                    Log.d("Loading", state.isLoading.toString())
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier.fillMaxSize(),
@@ -78,9 +77,9 @@ fun SearchGithubView(
                     Log.d("Error Log", state.error)
                 }
 
-                else -> {
+                state.data != null -> {
                     LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        items(state.data!!) {
+                        items(state.data) {
                             Row(modifier = Modifier.clickable { goToDetailView(it) }) {
                                 AsyncImage(
                                     model = it.owner.avatarUrl,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchGithubView.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchGithubView.kt
@@ -2,10 +2,14 @@ package jp.co.yumemi.android.code_check.view
 
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -24,22 +28,25 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.viewModel.SearchGithubViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchGithubView(
     viewModel: SearchGithubViewModel = hiltViewModel(),
-    goToDetailView: () -> Unit
+    goToDetailView: (Item) -> Unit,
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(text = "Android Engineer CodeCheck") },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary)
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.primary),
             )
-        }
+        },
     ) { inner ->
         Column(modifier = Modifier.padding(inner)) {
             OutlinedTextField(
@@ -51,7 +58,7 @@ fun SearchGithubView(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 keyboardActions = KeyboardActions(onDone = { viewModel.searchGithubRepository() }),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             )
             val state = viewModel.state.value
             val ctx = LocalContext.current
@@ -60,20 +67,28 @@ fun SearchGithubView(
                     Log.d("Loading", state.isLoading.toString())
                     Box(
                         contentAlignment = Alignment.Center,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize(),
                     ) {
                         CircularProgressIndicator()
                     }
                 }
 
                 !state.error.isNullOrBlank() -> {
-                    Toast.makeText(ctx, state.error, Toast.LENGTH_LONG).show()
+                    Toast.makeText(ctx, "検索できませんでした", Toast.LENGTH_LONG).show()
+                    Log.d("Error Log", state.error)
                 }
 
                 else -> {
-                    LazyColumn {
-                        items(state.data) {
-                            Text(text = it.name)
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        items(state.data!!) {
+                            Row(modifier = Modifier.clickable { goToDetailView(it) }) {
+                                AsyncImage(
+                                    model = it.owner.avatarUrl,
+                                    contentDescription = "Image",
+                                    modifier = Modifier.height(40.dp),
+                                )
+                                Text(text = it.name)
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
@@ -1,0 +1,44 @@
+package jp.co.yumemi.android.code_check.viewModel
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.yumemi.android.code_check.common.NetworkResponse
+import jp.co.yumemi.android.code_check.common.State.GithubRepositoryState
+import jp.co.yumemi.android.code_check.model.Item
+import jp.co.yumemi.android.code_check.viewModel.utlil.SearchGithubUtil
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@HiltViewModel
+class GithubDetailViewModel
+@Inject
+constructor(
+    private val searchGithubUtil: SearchGithubUtil,
+) : ViewModel() {
+    private val _state = mutableStateOf(GithubRepositoryState<Item>())
+    val state: State<GithubRepositoryState<Item>> = _state
+
+    fun getGithubDetail(
+        name: String,
+        owner: String,
+    ) {
+        searchGithubUtil.getRepositoryDetail(name = name, owner = owner).onEach { result ->
+            when (result) {
+                is NetworkResponse.Loading -> {
+                    _state.value = GithubRepositoryState(isLoading = true)
+                }
+                is NetworkResponse.Failure -> {
+                    _state.value = GithubRepositoryState(error = result.error)
+                }
+                is NetworkResponse.Success -> {
+                    _state.value = GithubRepositoryState(data = result.data)
+                }
+            }
+        }
+            .launchIn(viewModelScope)
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/SearchGithubViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/SearchGithubViewModel.kt
@@ -9,26 +9,31 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.code_check.common.NetworkResponse
 import jp.co.yumemi.android.code_check.common.State.GithubRepositoryState
+import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.viewModel.utlil.SearchGithubUtil
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @HiltViewModel
-class SearchGithubViewModel @Inject constructor(
-    private val searchGithubUtil: SearchGithubUtil
+class SearchGithubViewModel
+@Inject
+constructor(
+    private val searchGithubUtil: SearchGithubUtil,
 ) : ViewModel() {
-    private val _state = mutableStateOf(GithubRepositoryState())
-    val state: State<GithubRepositoryState> = _state
+    private val _state = mutableStateOf(GithubRepositoryState<List<Item>>())
+    val state: State<GithubRepositoryState<List<Item>>> = _state
     var query by mutableStateOf("")
 
     fun searchGithubRepository() {
         searchGithubUtil.searchGithubRepository(query).onEach { result ->
             when (result) {
                 is NetworkResponse.Success -> {
-                    _state.value = GithubRepositoryState(
-                        data = result.data.items, isLoading = false
-                    )
+                    _state.value =
+                        GithubRepositoryState(
+                            data = result.data.items,
+                            isLoading = false,
+                        )
                 }
 
                 is NetworkResponse.Failure -> {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
@@ -1,24 +1,41 @@
 package jp.co.yumemi.android.code_check.viewModel.utlil
 
 import jp.co.yumemi.android.code_check.common.NetworkResponse
+import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.model.SearchGithubRepositoryModel
 import jp.co.yumemi.android.code_check.repository.GithubRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
-class SearchGithubUtil @Inject constructor(
-    private val githubRepository: GithubRepository
+class SearchGithubUtil
+@Inject
+constructor(
+    private val githubRepository: GithubRepository,
 ) {
-
     // query -> searchGithubRepositoryで検索 -> responseの取得
-    fun searchGithubRepository(query: String): Flow<NetworkResponse<SearchGithubRepositoryModel>> = flow {
-        try {
-            emit(NetworkResponse.Loading())
-            val result = githubRepository.searchGithubRepository(query)
-            emit(NetworkResponse.Success(data = result))
-        } catch (e: Exception) {
-            emit(NetworkResponse.Failure(error = e.toString()))
+    fun searchGithubRepository(query: String): Flow<NetworkResponse<SearchGithubRepositoryModel>> =
+        flow {
+            try {
+                emit(NetworkResponse.Loading())
+                val result = githubRepository.searchGithubRepository(query)
+                emit(NetworkResponse.Success(data = result))
+            } catch (e: Exception) {
+                emit(NetworkResponse.Failure(error = e.toString()))
+            }
         }
-    }
+
+    fun getRepositoryDetail(
+        name: String,
+        owner: String,
+    ): Flow<NetworkResponse<Item>> =
+        flow {
+            try {
+                emit(NetworkResponse.Loading())
+                val result = githubRepository.getGithubDetail(name, owner)
+                emit(NetworkResponse.Success(data = result))
+            } catch (e: Exception) {
+                emit(NetworkResponse.Failure(error = e.toString()))
+            }
+        }
 }


### PR DESCRIPTION
# 概要
Github Detail Viewmodelの処理を記述

## 目的
レポジトリ層からビュー層へデータを渡す処理

## 行ったこと
- GithubDetailのViewModelの作成
- GithubrepositoryStateクラスの変更
- ルーティング処理の追加
- レポジトリにgetGithubDetailメソッドの追加(処理は書いていいない)
- レンスポンス結果によるUIの反映処理
 

## 参考文献

## 備考