### PR TITLE
GitHub detail repository

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,5 +29,7 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+      - name: Run ktlint Format
+        run: ./gradlew ktlintFormat
       - name: Run ktlint
         run: ./gradlew ktlint

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -41,14 +41,14 @@ class MainActivity : ComponentActivity() {
                     composable(
                         route = ViewRoute.GithubDetailView.route,
                         arguments =
-                            listOf(
-                                navArgument("repo") {
-                                    type = NavType.StringType
-                                },
-                                navArgument("owner") {
-                                    type = NavType.StringType
-                                },
-                            ),
+                        listOf(
+                            navArgument("repo") {
+                                type = NavType.StringType
+                            },
+                            navArgument("owner") {
+                                type = NavType.StringType
+                            },
+                        ),
                     ) { backStackEntry ->
                         GithubDetailView(
                             goToSearchView = { navController.navigate(ViewRoute.SearchGithubView.route) },

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
                             goToDetailView = {
                                 navController.navigate(
                                     ViewRoute.GithubDetailView.route.replace(
-                                        "{repositoryName}",
+                                        "{repo}",
                                         it.name,
                                     ).replace("{owner}", it.owner.name),
                                 )
@@ -41,18 +41,18 @@ class MainActivity : ComponentActivity() {
                     composable(
                         route = ViewRoute.GithubDetailView.route,
                         arguments =
-                        listOf(
-                            navArgument("repositoryId") {
-                                type = NavType.StringType
-                            },
-                            navArgument("owner") {
-                                type = NavType.StringType
-                            },
-                        ),
+                            listOf(
+                                navArgument("repo") {
+                                    type = NavType.StringType
+                                },
+                                navArgument("owner") {
+                                    type = NavType.StringType
+                                },
+                            ),
                     ) { backStackEntry ->
                         GithubDetailView(
                             goToSearchView = { navController.navigate(ViewRoute.SearchGithubView.route) },
-                            repositoryName = checkNotNull(backStackEntry.arguments?.getString("repositoryId")),
+                            repositoryName = checkNotNull(backStackEntry.arguments?.getString("repo")),
                             repositoryOwner = checkNotNull(backStackEntry.arguments?.getString("owner")),
                         )
                     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ViewRoute.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ViewRoute.kt
@@ -3,5 +3,5 @@ package jp.co.yumemi.android.code_check
 sealed class ViewRoute(val route: String) {
     object SearchGithubView : ViewRoute("searchGithubView")
 
-    object GithubDetailView : ViewRoute("githubDetailView/{repositoryId}")
+    object GithubDetailView : ViewRoute("githubDetailView/{owner}/{repo}")
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubRepository.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.repository
 
+import android.util.Log
 import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.model.SearchGithubRepositoryModel
 import javax.inject.Inject
@@ -15,8 +16,9 @@ constructor(
 
     suspend fun getGithubDetail(
         owner: String,
-        name: String,
+        repo: String,
     ): Item {
-        TODO()
+        Log.d("GithubRepository", githubService.getGithubDetail(owner, repo).toString())
+        return githubService.getGithubDetail(owner, repo)
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubService.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/GithubService.kt
@@ -1,10 +1,20 @@
 package jp.co.yumemi.android.code_check.repository
 
+import jp.co.yumemi.android.code_check.model.Item
 import jp.co.yumemi.android.code_check.model.SearchGithubRepositoryModel
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface GithubService {
     @GET("search/repositories")
-    suspend fun searchGithubRepository(@Query("q") query: String): SearchGithubRepositoryModel
+    suspend fun searchGithubRepository(
+        @Query("q") query: String,
+    ): SearchGithubRepositoryModel
+
+    @GET("repos/{owner}/{repo}")
+    suspend fun getGithubDetail(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+    ): Item
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
@@ -1,7 +1,9 @@
 package jp.co.yumemi.android.code_check.viewModel
 
+import android.util.Log
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,9 +20,18 @@ class GithubDetailViewModel
 @Inject
 constructor(
     private val searchGithubUtil: SearchGithubUtil,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _state = mutableStateOf(GithubRepositoryState<Item>())
     val state: State<GithubRepositoryState<Item>> = _state
+
+    init {
+        val owner = checkNotNull(savedStateHandle.get<String>("owner"))
+        val repo = checkNotNull(savedStateHandle.get<String>("repo"))
+        Log.d("owner", owner)
+        Log.d("repo", repo)
+        getGithubDetail(repo = repo, owner = owner)
+    }
 
     fun getGithubDetail(
         repo: String,

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/GithubDetailViewModel.kt
@@ -23,10 +23,10 @@ constructor(
     val state: State<GithubRepositoryState<Item>> = _state
 
     fun getGithubDetail(
-        name: String,
+        repo: String,
         owner: String,
     ) {
-        searchGithubUtil.getRepositoryDetail(name = name, owner = owner).onEach { result ->
+        searchGithubUtil.getRepositoryDetail(repo = repo, owner = owner).onEach { result ->
             when (result) {
                 is NetworkResponse.Loading -> {
                     _state.value = GithubRepositoryState(isLoading = true)
@@ -35,6 +35,7 @@ constructor(
                     _state.value = GithubRepositoryState(error = result.error)
                 }
                 is NetworkResponse.Success -> {
+                    Log.d("Response", _state.value.data.toString())
                     _state.value = GithubRepositoryState(data = result.data)
                 }
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
@@ -32,7 +32,7 @@ constructor(
         flow {
             try {
                 emit(NetworkResponse.Loading())
-                val result = githubRepository.getGithubDetail(repo = repo, owner = owner)
+                val result = githubRepository.getGithubDetail(owner = owner, repo = repo)
                 emit(NetworkResponse.Success(data = result))
             } catch (e: Exception) {
                 emit(NetworkResponse.Failure(error = e.toString()))

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewModel/utlil/SearchGithubUtil.kt
@@ -26,13 +26,13 @@ constructor(
         }
 
     fun getRepositoryDetail(
-        name: String,
+        repo: String,
         owner: String,
     ): Flow<NetworkResponse<Item>> =
         flow {
             try {
                 emit(NetworkResponse.Loading())
-                val result = githubRepository.getGithubDetail(name, owner)
+                val result = githubRepository.getGithubDetail(repo = repo, owner = owner)
                 emit(NetworkResponse.Success(data = result))
             } catch (e: Exception) {
                 emit(NetworkResponse.Failure(error = e.toString()))


### PR DESCRIPTION
#　概要
Github DetailのRepositoryの実装

## 目的
Repositoryから`owner`,`name`からレポジトリの詳細情報を取得する

## 行ったこと
- search Viewから`owner`,`name`の引数をもらう実装
- github endpointと名前を統一する

## 参考文献

## 備考